### PR TITLE
Added AsyncStaleHTTPClient that uses tornado coroutine to access self.cache methods

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,6 @@ setup(
     include_package_data=True,
     install_requires=[
         'tornado',
-        'redis',
+        'smart-sentinel>=0.2.0',
     ],
 )


### PR DESCRIPTION
Hi guys.

We need to support asynchronous redis client, now this library supports only default redis client that is synchronous.

This PR create a Async access class.
If we have async tornado Redis client, common Redis methods like `set` and `get` need to be called with `yield` and need internal methods from tornado stale client needs to be a coroutine.

I've isolated common methods in a Base class `BaseStaleHTTPClient` and overwritten needed methods in Async class `AsyncStaleHTTPClient`.
