### PR TITLE
feature: support ttl and stale_ttl per request

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,14 @@ def main():
     print(response.code, 'GET', url, response.body)
 ```
 
+You can also configure `ttl` and `stale_ttl` per request
+
+```python
+    # ...
+    response = yield client.fetch('http://...', ttl=1, stale_ttl=300)
+```
+
+
 Check [example.py](example.py) for a runnable demo.
 
 


### PR DESCRIPTION
allow users to set specific ttl and stale ttl per request,
respecting old interface.

add tests to this new behavior